### PR TITLE
ci: Add test framework and a simple test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,30 @@ on:
       - next
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: npm install
+        run: |
+          npm install
+        env:
+          CI: true
+      - name: npm test
+        run: |
+          npm test
+        env:
+          CI: true
+
   release:
     name: Release
     runs-on: ubuntu-latest
+    needs: [test]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Run Lint and Tests
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        node-version: [14.x, 16.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm install
+        run: |
+          npm install
+      - name: Run tests
+        run: |
+          npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,14 @@
+assets.json
+package-lock.json
 node_modules
+tmp
+.nyc_output
+node_modules/**/*
+.DS_Store
+tmp/**/*
+.idea
+.idea/**/*
+*.iml
+*.log
+coverage
+.vscode

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,10 +1,10 @@
-const verifyConditions = require("./lib/verify-conditions");
-const analyzeCommits = require("./lib/analyze-commits");
-const verifyRelease = require("./lib/verify-release");
-const generateNotes = require("./lib/generate-notes");
-const prepare = require("./lib/prepare");
-const publish = require("./lib/publish");
-const success = require("./lib/success");
+const verifyConditions = require("./verify-conditions");
+const analyzeCommits = require("./analyze-commits");
+const verifyRelease = require("./verify-release");
+const generateNotes = require("./generate-notes");
+const prepare = require("./prepare");
+const publish = require("./publish");
+const success = require("./success");
 
 class State {
   eikToken = "";

--- a/package.json
+++ b/package.json
@@ -2,16 +2,17 @@
   "name": "@eik/semantic-release",
   "version": "1.0.0",
   "description": "Semantic release plugin for Eik",
-  "main": "index.js",
+  "main": "lib/main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "tap --no-check-coverage",
+    "test:snapshots:update": "tap --snapshot"
   },
   "publishConfig": {
     "access": "public"
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@eik/cli": "^2.0.0-next.6",
     "@eik/common": "^4.0.0-next.4",
@@ -20,12 +21,9 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "@semantic-release/changelog": "5.0.1",
-    "@semantic-release/commit-analyzer": "8.0.1",
-    "@semantic-release/git": "9.0.0",
-    "@semantic-release/github": "7.2.3",
-    "@semantic-release/npm": "7.1.3",
-    "@semantic-release/release-notes-generator": "9.0.3",
-    "semantic-release": "17.4.4"
+    "@semantic-release/changelog": "6.0.1",
+    "@semantic-release/git": "10.0.1",
+    "semantic-release": "19.0.2",
+    "tap": "15.1.6"
   }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const plugin = require('../lib/main.js');
+const tap = require('tap');
+
+tap.test('Simple test', (t) => {
+    t.type(plugin.verifyConditions, 'function');
+    t.type(plugin.analyzeCommits, 'function');
+    t.type(plugin.verifyRelease, 'function');
+    t.type(plugin.generateNotes, 'function');
+    t.type(plugin.prepare, 'function');
+    t.type(plugin.publish, 'function');
+    t.type(plugin.success, 'function');
+    t.end();
+});


### PR DESCRIPTION
This module is currently a CommonJS module (can not be ported to ESM before Semantic Release is) but some of the dependencies it depend on have started to publish ESM only versions. This repo does also lack tests. Most concerning at the moment is that this repo is under the regime of getting automated dependency updates and automatic release so there might become a situation where a dependency which is ESM only is automatically merged and a version of this module is automatically published due to no tests checking the module and breaking the publish process. That will then be a broken version since CommonJS can not use ESM modules.

This adds a test framework and adds a simple test to make sure the above does not happen.